### PR TITLE
Add full generative UI: slot/faction/location generation, batch roste…

### DIFF
--- a/populator/orchestrator.py
+++ b/populator/orchestrator.py
@@ -13,8 +13,48 @@ from .generation.schemas import (
     GeneratedFaction,
     GeneratedLocation,
     MobArchetype,
+    RankDefinition,
 )
 from .models import Campaign, Character, Faction, Location
+
+
+# --- DB -> pydantic reconstruction ----------------------------------------
+# The UI generates one card at a time against *stored* campaign data, so
+# the engine's context objects are rebuilt from rows rather than carried
+# over from a live pipeline run.
+
+
+def to_generated_location(location: Location) -> GeneratedLocation:
+    return GeneratedLocation(
+        name=location.name,
+        location_type=location.location_type,
+        description=location.description,
+        summary=location.summary or location.description,
+    )
+
+
+def to_generated_faction(faction: Faction) -> GeneratedFaction:
+    return GeneratedFaction(
+        name=faction.name,
+        faction_type=faction.faction_type,
+        alignment=faction.alignment,
+        description=faction.description,
+        hierarchy=[RankDefinition(**rank) for rank in faction.hierarchy],
+    )
+
+
+def to_generated_characters(faction: Faction) -> list[GeneratedCharacter]:
+    """Existing roster as engine context (so new characters don't clash)."""
+    return [
+        GeneratedCharacter(
+            name=c.name,
+            race=c.race,
+            alignment=c.alignment,
+            rank_title=c.rank_title,
+            description=c.description,
+        )
+        for c in faction.characters.all()
+    ]
 
 
 def save_location(

--- a/populator/templates/populator/base.html
+++ b/populator/templates/populator/base.html
@@ -5,6 +5,7 @@
     <meta charset="utf-8">
     <meta name="viewport" content="width=device-width, initial-scale=1">
     <title>{% block title %}DCMaker{% endblock %}</title>
+    <script src="https://cdn.jsdelivr.net/npm/htmx.org@2.0.4/dist/htmx.min.js"></script>
     <style>
         :root {
             --bg: #16151c; --panel: #211f2b; --edge: #35323f;
@@ -55,6 +56,20 @@
         .effect.legendary { border-left-color: #7a4fb0; }
         .effecthead { display: flex; justify-content: space-between; align-items: baseline; margin-bottom: 0.15rem; }
         .effecthead .kind { font-size: 0.68rem; color: var(--dim); text-transform: uppercase; letter-spacing: 0.05em; }
+        .slotform { flex-direction: column; gap: 0.5rem; padding: 0.9rem; }
+        .slotform textarea { width: 100%; background: var(--bg); border: 1px solid var(--edge);
+                             border-radius: 4px; color: var(--text); font-family: inherit;
+                             font-size: 0.85rem; padding: 0.4rem; resize: vertical; }
+        .slotform button { background: var(--accent); color: var(--bg); border: none; border-radius: 4px;
+                           padding: 0.4rem 0.9rem; font-family: inherit; font-weight: bold; cursor: pointer; }
+        .slotform button:disabled { opacity: 0.5; cursor: wait; }
+        .htmx-indicator { display: none; color: var(--accent); font-style: italic; font-size: 0.85rem; }
+        .htmx-request .htmx-indicator, .htmx-request.htmx-indicator { display: inline; }
+        .card.plus { border-style: dashed; color: var(--dim); }
+        .card.plus summary { cursor: pointer; list-style: none; text-align: center;
+                             font-size: 1.6rem; line-height: 2.2rem; }
+        .card.plus[open] summary { text-align: left; font-size: 1rem; }
+        .card.plus form { display: flex; flex-direction: column; gap: 0.5rem; margin-top: 0.4rem; }
     </style>
 </head>
 <body>

--- a/populator/templates/populator/faction_detail.html
+++ b/populator/templates/populator/faction_detail.html
@@ -19,8 +19,34 @@
     {% include "populator/_character_card.html" %}
     {% endfor %}
     {% for _ in group.empty_slots %}
-    <div class="card empty">empty slot — generation coming soon</div>
+    <form class="card empty slotform"
+          hx-post="{% url 'generate_character_slot' faction.pk %}"
+          hx-swap="outerHTML"
+          hx-disabled-elt="find button">
+        {% csrf_token %}
+        <input type="hidden" name="rank_title" value="{{ group.rank.title }}">
+        <textarea name="hints" rows="2"
+                  placeholder="Optional direction for this {{ group.rank.title }}..."></textarea>
+        <button type="submit">⚔ Generate</button>
+        <span class="htmx-indicator">consulting the fates…</span>
+    </form>
     {% endfor %}
+    <details class="card plus">
+        <summary>＋</summary>
+        <form class="slotform"
+              hx-post="{% url 'generate_character_slot' faction.pk %}"
+              hx-target="closest details"
+              hx-swap="beforebegin"
+              hx-disabled-elt="find button"
+              hx-on::after-request="this.reset(); this.closest('details').open = false">
+            {% csrf_token %}
+            <input type="hidden" name="rank_title" value="{{ group.rank.title }}">
+            <textarea name="hints" rows="2"
+                      placeholder="Optional direction for another {{ group.rank.title }}..."></textarea>
+            <button type="submit">⚔ Generate another</button>
+            <span class="htmx-indicator">consulting the fates…</span>
+        </form>
+    </details>
 </div>
 {% endfor %}
 {% endblock %}

--- a/populator/urls.py
+++ b/populator/urls.py
@@ -8,4 +8,9 @@ urlpatterns = [
     path("campaigns/<int:pk>/", views.campaign_detail, name="campaign_detail"),
     path("locations/<int:pk>/", views.location_detail, name="location_detail"),
     path("factions/<int:pk>/", views.faction_detail, name="faction_detail"),
+    path(
+        "factions/<int:pk>/generate/",
+        views.generate_character_slot,
+        name="generate_character_slot",
+    ),
 ]

--- a/populator/views.py
+++ b/populator/views.py
@@ -10,7 +10,11 @@ can only ever see their own campaigns' content.
 
 from django.contrib.auth.decorators import login_required
 from django.shortcuts import get_object_or_404, render
+from django.views.decorators.http import require_POST
 
+from . import orchestrator
+from .generation import generate as engine
+from .generation.schemas import RankTier
 from .models import Campaign, Faction, Location
 
 
@@ -65,3 +69,40 @@ def faction_detail(request, pk):
         "populator/faction_detail.html",
         {"faction": faction, "groups": groups},
     )
+
+
+@login_required
+@require_POST
+def generate_character_slot(request, pk):
+    """htmx endpoint: fill one empty slot. Returns a single character
+    card fragment that swaps in place of the empty-slot form."""
+    faction = get_object_or_404(
+        Faction, pk=pk, location__campaign__owner=request.user
+    )
+    rank_title = request.POST.get("rank_title", "")
+    hints = request.POST.get("hints", "").strip()
+
+    gen_location = orchestrator.to_generated_location(faction.location)
+    gen_faction = orchestrator.to_generated_faction(faction)
+    slot = engine.slot_for_title(gen_faction, rank_title)
+    party_level = faction.location.party_level
+
+    if slot.tier is RankTier.MOB:
+        archetype = engine.generate_mob_archetypes(gen_location, gen_faction, [slot])[0]
+        character = orchestrator.save_mob_archetype(faction, archetype)
+        sheet_subject = archetype
+    else:
+        generated = engine.generate_character(
+            gen_location,
+            gen_faction,
+            slot,
+            existing=orchestrator.to_generated_characters(faction),
+            user_hints=hints,
+        )
+        character = orchestrator.save_character(faction, generated)
+        sheet_subject = generated
+
+    sheet = engine.generate_combat_sheet(sheet_subject, gen_faction, party_level, slot)
+    orchestrator.save_combat_sheet(character, sheet)
+
+    return render(request, "populator/_character_card.html", {"character": character})


### PR DESCRIPTION
## What

**The generation loop, in the browser at every level:**
- Campaign list (+): create a campaign (plain form, no AI).
- Campaign page (+): generate a location from a DM concept + party level.
- Location page (+): generate factions with DM direction and a count —
  1 adds a single faction generated *in contrast to* existing factions
  (passed as context); 2–5 generates a contrasting batch.
- Faction page: one slot form per rank with a fill counter ("1 of 3");
  completing a slot swaps in the character card plus the next form.
  Every rank keeps a persistent (+) tile for extra characters beyond
  the designed positions.
- Batch roster button on empty factions (fills the whole hierarchy +
  combat sheets in one click; hides once characters exist).
- Mob (+) lets the DM name brand-new archetype types on the spot.

**Layout & data hygiene:**
- All mob-tier content consolidated into one "Mobs" section; rank
  titles match fuzzily (parentheticals stripped), so model-decorated
  titles no longer orphan their archetypes. Prompt updated to keep
  titles short.
- Delete controls with confirmation: ✕ per character card (swaps out
  in place) and a cascading faction delete that returns to the
  location page.

**Engine/orchestrator support:**
- DB→pydantic reconstruction (`to_generated_location/faction/characters`)
  so generation runs against stored campaign data.
- Cross-faction dossier: named figures from the location's other
  factions (name, rank, tier, snippet) passed to character generation,
  enabling woven rivalries and alliances (~450 tokens ≈ negligible cost).
- htmx (CDN) with global CSRF via a header on <body>; card and slot-form
  partials shared between full pages and htmx fragment responses.

## Why

This is the product's core loop — the DM decides what to generate,
where, and steers every step with their own words. Everything previously
required the terminal; a stranger can now build a world from a browser.

## Testing

Django test-client smoke tests across all pages (auth redirects,
ownership filtering, form/tile/card counts, fragment rendering).
Exercised live end-to-end: locations, factions (batch and single),
characters via slot forms and (+), batch roster fill, deletes with
confirm, mob archetype creation by name.