### PR TITLE
Add remaining generative UI files missed from previous commit

### DIFF
--- a/populator/generation/generate.py
+++ b/populator/generation/generate.py
@@ -46,12 +46,20 @@ def generate_location(concept: str) -> GeneratedLocation:
 
 
 def generate_factions(
-    location: GeneratedLocation, num_factions: int = 3
+    location: GeneratedLocation,
+    num_factions: int = 3,
+    hints: str = "",
+    existing: list[str] | None = None,
 ) -> list[GeneratedFaction]:
+    """`existing` is short one-line summaries of factions already at the
+    location, so additions (especially single ones) contrast rather
+    than duplicate."""
     prompt = _prompt("factions").format(
         location_name=location.name,
         location_summary=location.summary,
         num_factions=num_factions,
+        faction_hints=hints or "(none provided)",
+        existing_factions="\n".join(f"- {line}" for line in existing) if existing else "(none yet)",
     )
     return generate(prompt, FactionSet, SYSTEM).factions
 
@@ -75,11 +83,18 @@ def _roster_lines(existing: list[GeneratedCharacter]) -> str:
     )
 
 
+def _other_faction_lines(other_factions: list[str] | None) -> str:
+    if not other_factions:
+        return "(none known)"
+    return "\n".join(f"- {line}" for line in other_factions)
+
+
 def fill_roster(
     location: GeneratedLocation,
     faction: GeneratedFaction,
     slots: list[RankDefinition],
     existing: list[GeneratedCharacter] | None = None,
+    other_factions: list[str] | None = None,
 ) -> list[GeneratedCharacter]:
     """Fill several empty named-character slots in one call (planning
     mode). Mob-tier slots don't belong here — they become archetypes
@@ -97,6 +112,7 @@ def fill_roster(
     prompt = _prompt("roster_batch").format(
         slot_list=slot_list,
         existing_roster=_roster_lines(existing or []),
+        other_factions=_other_faction_lines(other_factions),
         **_faction_context(location, faction),
     )
     return generate(prompt, CharacterSet, SYSTEM).characters
@@ -126,17 +142,21 @@ def generate_character(
     slot: RankDefinition,
     existing: list[GeneratedCharacter] | None = None,
     user_hints: str = "",
+    other_factions: list[str] | None = None,
 ) -> GeneratedCharacter:
     """Fill one slot (the (+) button, a regenerate, or in-game use).
 
     `user_hints` is the DM's typed direction from the card's editable
     fields; empty means the model improvises from context.
+    `other_factions` is short dossier lines on named figures elsewhere
+    at the location, enabling cross-faction relationships.
     """
     prompt = _prompt("roster_single").format(
         rank_title=slot.title,
         rank_tier=slot.tier.value,
         user_hints=user_hints or "(none provided)",
         existing_roster=_roster_lines(existing or []),
+        other_factions=_other_faction_lines(other_factions),
         **_faction_context(location, faction),
     )
     return generate(prompt, GeneratedCharacter, SYSTEM)

--- a/populator/orchestrator.py
+++ b/populator/orchestrator.py
@@ -43,6 +43,23 @@ def to_generated_faction(faction: Faction) -> GeneratedFaction:
     )
 
 
+def other_faction_dossier(faction: Faction) -> list[str]:
+    """Short lines on named figures in the location's *other* factions,
+    so new characters can carry cross-faction relationships. Named
+    tiers only — mob flavor would dilute the context for no gain."""
+    lines = []
+    others = faction.location.factions.exclude(pk=faction.pk).filter(
+        is_catchall=False
+    )
+    for other in others:
+        for ch in other.characters.exclude(rank_tier=Character.RankTier.MOB):
+            snippet = ch.description.split(".")[0][:120]
+            lines.append(
+                f"{ch.name} — {ch.rank_title} ({ch.rank_tier}) of {other.name}: {snippet}"
+            )
+    return lines
+
+
 def to_generated_characters(faction: Faction) -> list[GeneratedCharacter]:
     """Existing roster as engine context (so new characters don't clash)."""
     return [

--- a/populator/templates/populator/_character_card.html
+++ b/populator/templates/populator/_character_card.html
@@ -1,5 +1,9 @@
 {# One character card. Included by faction_detail; will be the htmx swap target later. #}
 <div class="card character">
+    <button class="del" title="Delete {{ character.name }}"
+            hx-post="{% url 'character_delete' character.pk %}"
+            hx-confirm="Delete {{ character.name }}? This cannot be undone."
+            hx-target="closest .card" hx-swap="outerHTML">✕</button>
     <div class="cardtop">
         <div class="portrait">🎭<span>art pending</span></div>
         <div>

--- a/populator/templates/populator/_faction_cards.html
+++ b/populator/templates/populator/_faction_cards.html
@@ -1,0 +1,7 @@
+{% for faction in factions %}
+<div class="card">
+    <a href="{% url 'faction_detail' faction.pk %}">{{ faction.name }}</a>
+    <div class="meta">{{ faction.faction_type }} · {{ faction.alignment }}{% if faction.is_catchall %} · catch-all{% endif %}</div>
+    <p>{{ faction.description|truncatewords:30 }}</p>
+</div>
+{% endfor %}

--- a/populator/templates/populator/_location_card.html
+++ b/populator/templates/populator/_location_card.html
@@ -1,0 +1,5 @@
+<div class="card">
+    <a href="{% url 'location_detail' location.pk %}">{{ location.name }}</a>
+    <div class="meta">{{ location.location_type }} · party level {{ location.party_level }}</div>
+    <p>{{ location.summary|truncatewords:30 }}</p>
+</div>

--- a/populator/templates/populator/_slot_form.html
+++ b/populator/templates/populator/_slot_form.html
@@ -1,0 +1,17 @@
+{# One empty-slot form; swaps out for the generated card + next form. #}{% comment %}
+Multi-line notes belong in comment blocks like this one — a {# #} spanning
+two lines renders as page text (we learned this the visible way).
+{% endcomment %}
+<form class="card empty slotform"
+      hx-post="{% url 'generate_character_slot' faction.pk %}"
+      hx-swap="outerHTML"
+      hx-disabled-elt="find button">
+    {% csrf_token %}
+    <input type="hidden" name="rank_title" value="{{ rank_title }}">
+    <input type="hidden" name="remaining" value="{{ remaining }}">
+    {% if tier %}<input type="hidden" name="tier" value="{{ tier }}">{% endif %}
+    <textarea name="hints" rows="2"
+              placeholder="Optional direction for this {{ rank_title }}..."></textarea>
+    <button type="submit">⚔ Generate{% if remaining > 1 %} (1 of {{ remaining }}){% endif %}</button>
+    <span class="htmx-indicator">consulting the fates…</span>
+</form>

--- a/populator/templates/populator/base.html
+++ b/populator/templates/populator/base.html
@@ -70,9 +70,23 @@
                              font-size: 1.6rem; line-height: 2.2rem; }
         .card.plus[open] summary { text-align: left; font-size: 1rem; }
         .card.plus form { display: flex; flex-direction: column; gap: 0.5rem; margin-top: 0.4rem; }
+        .slotform input[type="text"], .slotform input[type="number"] {
+            background: var(--bg); border: 1px solid var(--edge); border-radius: 4px;
+            color: var(--text); font-family: inherit; font-size: 0.85rem; padding: 0.4rem; }
+        .del { background: none; border: none; color: var(--dim); cursor: pointer;
+               font-size: 0.9rem; float: right; padding: 0 0.2rem; }
+        .del:hover { color: var(--leadership); }
+        .dangerbtn { background: none; border: 1px solid var(--leadership); color: var(--leadership);
+                     border-radius: 4px; padding: 0.3rem 0.7rem; font-family: inherit;
+                     font-size: 0.85rem; cursor: pointer; }
+        .dangerbtn:hover { background: var(--leadership); color: #fff; }
+        .toolbar { display: flex; gap: 0.6rem; align-items: center; margin: 0.8rem 0; }
+        .toolbar .accentbtn { background: var(--accent); color: var(--bg); border: none;
+                              border-radius: 4px; padding: 0.35rem 0.8rem; font-family: inherit;
+                              font-weight: bold; cursor: pointer; }
     </style>
 </head>
-<body>
+<body hx-headers='{"X-CSRFToken": "{{ csrf_token }}"}'>
     <header>
         <a href="{% url 'campaign_list' %}">⚔ DCMaker</a>
         <span class="crumbs">{% block crumbs %}{% endblock %}</span>

--- a/populator/templates/populator/campaign_detail.html
+++ b/populator/templates/populator/campaign_detail.html
@@ -5,15 +5,25 @@
 <h1>{{ campaign.name }}</h1>
 <p class="sub">{{ campaign.description }}</p>
 <h2>Locations</h2>
-<div class="cards">
+<div class="cards" id="locations">
     {% for location in campaign.locations.all %}
-    <div class="card">
-        <a href="{% url 'location_detail' location.pk %}">{{ location.name }}</a>
-        <div class="meta">{{ location.location_type }} · party level {{ location.party_level }}</div>
-        <p>{{ location.summary|truncatewords:30 }}</p>
-    </div>
-    {% empty %}
-    <div class="card empty">No locations yet.</div>
+    {% include "populator/_location_card.html" %}
     {% endfor %}
+    <details class="card plus">
+        <summary>＋</summary>
+        <form class="slotform"
+              hx-post="{% url 'generate_location_slot' campaign.pk %}"
+              hx-target="closest details"
+              hx-swap="beforebegin"
+              hx-disabled-elt="find button"
+              hx-on::after-request="this.reset(); this.closest('details').open = false">
+            {% csrf_token %}
+            <textarea name="concept" rows="3"
+                      placeholder="Location concept — e.g. 'a mining town sealed inside a mysterious veil'..."></textarea>
+            <input type="number" name="party_level" value="5" min="1" max="20" title="Party level">
+            <button type="submit">⚔ Generate location</button>
+            <span class="htmx-indicator">raising the land from the mists…</span>
+        </form>
+    </details>
 </div>
 {% endblock %}

--- a/populator/templates/populator/campaign_list.html
+++ b/populator/templates/populator/campaign_list.html
@@ -10,8 +10,15 @@
         <div class="meta">{{ campaign.locations.count }} location{{ campaign.locations.count|pluralize }}</div>
         <p>{{ campaign.description|truncatewords:25 }}</p>
     </div>
-    {% empty %}
-    <div class="card empty">No campaigns yet — create one in the admin for now.</div>
     {% endfor %}
+    <details class="card plus" {% if not campaigns %}open{% endif %}>
+        <summary>＋</summary>
+        <form class="slotform" method="post" action="{% url 'campaign_create' %}">
+            {% csrf_token %}
+            <input type="text" name="name" placeholder="Campaign name" maxlength="100" required>
+            <textarea name="description" rows="2" placeholder="What's this campaign about? (optional)"></textarea>
+            <button type="submit">Create campaign</button>
+        </form>
+    </details>
 </div>
 {% endblock %}

--- a/populator/templates/populator/faction_detail.html
+++ b/populator/templates/populator/faction_detail.html
@@ -9,6 +9,21 @@
 <p class="sub">{{ faction.faction_type }} · {{ faction.alignment }}</p>
 <p>{{ faction.description|linebreaks }}</p>
 
+<div class="toolbar">
+    {% if not has_characters %}
+    <form method="post" action="{% url 'generate_roster_batch' faction.pk %}"
+          onsubmit="var b=this.querySelector('button'); b.disabled=true; b.textContent='Generating full roster — this takes a few minutes…';">
+        {% csrf_token %}
+        <button type="submit" class="accentbtn">⚔ Generate full roster</button>
+    </form>
+    {% endif %}
+    <button class="dangerbtn"
+            hx-post="{% url 'faction_delete' faction.pk %}"
+            hx-confirm="Delete {{ faction.name }} and ALL its characters? This cannot be undone.">
+        ✕ Delete faction
+    </button>
+</div>
+
 {% for group in groups %}
 <h2>
     {{ group.rank.title }}
@@ -18,19 +33,9 @@
     {% for character in group.characters %}
     {% include "populator/_character_card.html" %}
     {% endfor %}
-    {% for _ in group.empty_slots %}
-    <form class="card empty slotform"
-          hx-post="{% url 'generate_character_slot' faction.pk %}"
-          hx-swap="outerHTML"
-          hx-disabled-elt="find button">
-        {% csrf_token %}
-        <input type="hidden" name="rank_title" value="{{ group.rank.title }}">
-        <textarea name="hints" rows="2"
-                  placeholder="Optional direction for this {{ group.rank.title }}..."></textarea>
-        <button type="submit">⚔ Generate</button>
-        <span class="htmx-indicator">consulting the fates…</span>
-    </form>
-    {% endfor %}
+    {% if group.remaining > 0 %}
+    {% include "populator/_slot_form.html" with rank_title=group.rank.title remaining=group.remaining %}
+    {% endif %}
     <details class="card plus">
         <summary>＋</summary>
         <form class="slotform"
@@ -49,4 +54,30 @@
     </details>
 </div>
 {% endfor %}
+
+<h2>Mobs <span class="badge mob">shared stat blocks</span></h2>
+<div class="cards">
+    {% for character in mob_archetypes %}
+    {% include "populator/_character_card.html" %}
+    {% endfor %}
+    {% for rank in mob_unfilled %}
+    {% include "populator/_slot_form.html" with rank_title=rank.title remaining=1 tier="mob" %}
+    {% endfor %}
+    <details class="card plus">
+        <summary>＋</summary>
+        <form class="slotform"
+              hx-post="{% url 'generate_character_slot' faction.pk %}"
+              hx-target="closest details"
+              hx-swap="beforebegin"
+              hx-disabled-elt="find button"
+              hx-on::after-request="this.reset(); this.closest('details').open = false">
+            {% csrf_token %}
+            <input type="hidden" name="tier" value="mob">
+            <input type="text" name="rank_title" placeholder="New mob type — e.g. 'Lantern Hound'" required>
+            <textarea name="hints" rows="2" placeholder="Optional direction..."></textarea>
+            <button type="submit">⚔ Generate archetype</button>
+            <span class="htmx-indicator">consulting the fates…</span>
+        </form>
+    </details>
+</div>
 {% endblock %}

--- a/populator/templates/populator/location_detail.html
+++ b/populator/templates/populator/location_detail.html
@@ -8,15 +8,24 @@
 <p class="sub">{{ location.location_type }} · party level {{ location.party_level }}</p>
 <p>{{ location.description|linebreaks }}</p>
 <h2>Factions</h2>
-<div class="cards">
-    {% for faction in location.factions.all %}
-    <div class="card">
-        <a href="{% url 'faction_detail' faction.pk %}">{{ faction.name }}</a>
-        <div class="meta">{{ faction.faction_type }} · {{ faction.alignment }}{% if faction.is_catchall %} · catch-all{% endif %}</div>
-        <p>{{ faction.description|truncatewords:30 }}</p>
-    </div>
-    {% empty %}
-    <div class="card empty">No factions yet.</div>
-    {% endfor %}
+<div class="cards" id="factions">
+    {% include "populator/_faction_cards.html" with factions=location.factions.all %}
+    <details class="card plus">
+        <summary>＋</summary>
+        <form class="slotform"
+              hx-post="{% url 'generate_faction_slots' location.pk %}"
+              hx-target="closest details"
+              hx-swap="beforebegin"
+              hx-disabled-elt="find button"
+              hx-on::after-request="this.reset(); this.closest('details').open = false">
+            {% csrf_token %}
+            <textarea name="hints" rows="3"
+                      placeholder="Optional direction — e.g. 'a smugglers' ring using the old mine tunnels'..."></textarea>
+            <label class="meta">How many? 1 adds a single faction that contrasts with the existing ones; more generates a contrasting batch.</label>
+            <input type="number" name="num_factions" value="1" min="1" max="5">
+            <button type="submit">⚔ Generate faction(s)</button>
+            <span class="htmx-indicator">stirring up rivalries…</span>
+        </form>
+    </details>
 </div>
 {% endblock %}

--- a/populator/urls.py
+++ b/populator/urls.py
@@ -5,12 +5,34 @@ from . import views
 
 urlpatterns = [
     path("", views.campaign_list, name="campaign_list"),
+    path("campaigns/create/", views.campaign_create, name="campaign_create"),
     path("campaigns/<int:pk>/", views.campaign_detail, name="campaign_detail"),
+    path(
+        "campaigns/<int:pk>/generate-location/",
+        views.generate_location_slot,
+        name="generate_location_slot",
+    ),
+    path(
+        "locations/<int:pk>/generate-factions/",
+        views.generate_faction_slots,
+        name="generate_faction_slots",
+    ),
     path("locations/<int:pk>/", views.location_detail, name="location_detail"),
     path("factions/<int:pk>/", views.faction_detail, name="faction_detail"),
     path(
         "factions/<int:pk>/generate/",
         views.generate_character_slot,
         name="generate_character_slot",
+    ),
+    path(
+        "factions/<int:pk>/generate-roster/",
+        views.generate_roster_batch,
+        name="generate_roster_batch",
+    ),
+    path("factions/<int:pk>/delete/", views.faction_delete, name="faction_delete"),
+    path(
+        "characters/<int:pk>/delete/",
+        views.character_delete,
+        name="character_delete",
     ),
 ]

--- a/populator/views.py
+++ b/populator/views.py
@@ -9,13 +9,16 @@ can only ever see their own campaigns' content.
 """
 
 from django.contrib.auth.decorators import login_required
-from django.shortcuts import get_object_or_404, render
+from django.http import HttpResponse
+from django.shortcuts import get_object_or_404, redirect, render
+from django.template.loader import render_to_string
+from django.urls import reverse
 from django.views.decorators.http import require_POST
 
 from . import orchestrator
 from .generation import generate as engine
 from .generation.schemas import RankTier
-from .models import Campaign, Faction, Location
+from .models import Campaign, Character, Faction, Location
 
 
 @login_required
@@ -42,33 +45,190 @@ def faction_detail(request, pk):
         Faction, pk=pk, location__campaign__owner=request.user
     )
 
-    # Group characters by their rank in the faction's hierarchy, ordered
-    # by level. Characters whose rank_title matches no hierarchy rank
-    # (DM-invented titles) get their own trailing groups.
+    # Named ranks get their own sections ordered by level; all mob-tier
+    # content is consolidated into one "Mobs" section. Titles are
+    # matched fuzzily (parentheticals stripped, case-insensitive) since
+    # the model sometimes decorates rank titles with descriptions.
+    def clean(title):
+        return title.split("(")[0].strip().lower()
+
     by_title: dict[str, list] = {}
+    stray_mobs = []
     for character in faction.characters.all():
-        by_title.setdefault(character.rank_title, []).append(character)
+        if character.rank_tier == "mob":
+            stray_mobs.append(character)
+        else:
+            by_title.setdefault(clean(character.rank_title), []).append(character)
 
     groups = []
+    mob_archetypes, mob_unfilled = [], []
     for rank in sorted(faction.hierarchy, key=lambda r: r.get("level", 99)):
-        characters = by_title.pop(rank["title"], [])
+        if rank["tier"] == "mob":
+            matched = [
+                m for m in stray_mobs if clean(m.rank_title) == clean(rank["title"])
+            ]
+            if matched:
+                mob_archetypes.extend(matched)
+                stray_mobs = [m for m in stray_mobs if m not in matched]
+            else:
+                mob_unfilled.append(rank)
+            continue
+        characters = by_title.pop(clean(rank["title"]), [])
         groups.append(
             {
                 "rank": rank,
                 "characters": characters,
-                "empty_slots": range(max(0, rank["positions"] - len(characters)))
-                if rank["tier"] != "mob"
-                else range(0 if characters else 1),
+                "remaining": max(0, rank["positions"] - len(characters)),
             }
         )
     for title, characters in by_title.items():
-        groups.append({"rank": {"title": title, "tier": "", "positions": len(characters)}, "characters": characters, "empty_slots": range(0)})
+        groups.append(
+            {
+                "rank": {"title": characters[0].rank_title, "tier": "", "positions": len(characters)},
+                "characters": characters,
+                "remaining": 0,
+            }
+        )
+    mob_archetypes.extend(stray_mobs)  # mobs with no matching rank still display
 
     return render(
         request,
         "populator/faction_detail.html",
-        {"faction": faction, "groups": groups},
+        {
+            "faction": faction,
+            "groups": groups,
+            "mob_archetypes": mob_archetypes,
+            "mob_unfilled": mob_unfilled,
+            "has_characters": faction.characters.exists(),
+        },
     )
+
+
+@login_required
+@require_POST
+def generate_roster_batch(request, pk):
+    """Fill the faction's whole hierarchy in one go: named characters
+    (one batch call), mob archetypes (one call), sheets for everyone.
+    The button only shows on empty factions, so no duplicate risk."""
+    faction = get_object_or_404(
+        Faction, pk=pk, location__campaign__owner=request.user
+    )
+    gen_location = orchestrator.to_generated_location(faction.location)
+    gen_faction = orchestrator.to_generated_faction(faction)
+    party_level = faction.location.party_level
+
+    named_slots = [s for s in gen_faction.hierarchy if s.tier is not RankTier.MOB]
+    mob_slots = [s for s in gen_faction.hierarchy if s.tier is RankTier.MOB]
+
+    if named_slots:
+        for generated in engine.fill_roster(
+            gen_location,
+            gen_faction,
+            named_slots,
+            other_factions=orchestrator.other_faction_dossier(faction),
+        ):
+            character = orchestrator.save_character(faction, generated)
+            sheet = engine.generate_combat_sheet(
+                generated, gen_faction, party_level,
+                engine.slot_for_title(gen_faction, generated.rank_title),
+            )
+            orchestrator.save_combat_sheet(character, sheet)
+    if mob_slots:
+        for archetype in engine.generate_mob_archetypes(
+            gen_location, gen_faction, mob_slots
+        ):
+            character = orchestrator.save_mob_archetype(faction, archetype)
+            sheet = engine.generate_combat_sheet(
+                archetype, gen_faction, party_level,
+                engine.slot_for_title(gen_faction, archetype.rank_title),
+            )
+            orchestrator.save_combat_sheet(character, sheet)
+
+    return redirect("faction_detail", pk=faction.pk)
+
+
+@login_required
+@require_POST
+def character_delete(request, pk):
+    """htmx endpoint: delete one character; the card swaps to nothing."""
+    character = get_object_or_404(
+        Character, pk=pk, faction__location__campaign__owner=request.user
+    )
+    character.delete()
+    return HttpResponse("")
+
+
+@login_required
+@require_POST
+def faction_delete(request, pk):
+    """htmx endpoint: delete a faction (cascades to its characters),
+    then send the browser to the location page."""
+    faction = get_object_or_404(
+        Faction, pk=pk, location__campaign__owner=request.user
+    )
+    location_pk = faction.location.pk
+    faction.delete()
+    response = HttpResponse("")
+    response["HX-Redirect"] = reverse("location_detail", args=[location_pk])
+    return response
+
+
+@login_required
+@require_POST
+def campaign_create(request):
+    """Plain form, no AI: a campaign is just a named container."""
+    campaign = Campaign.objects.create(
+        name=request.POST.get("name", "").strip() or "Untitled Campaign",
+        description=request.POST.get("description", "").strip(),
+        owner=request.user,
+    )
+    return redirect("campaign_detail", pk=campaign.pk)
+
+
+@login_required
+@require_POST
+def generate_location_slot(request, pk):
+    """htmx endpoint: generate a location from the DM's concept and
+    return its card fragment."""
+    campaign = get_object_or_404(Campaign, pk=pk, owner=request.user)
+    concept = request.POST.get("concept", "").strip() or "A memorable adventuring locale"
+    try:
+        party_level = int(request.POST.get("party_level", 5))
+    except ValueError:
+        party_level = 5
+
+    generated = engine.generate_location(concept)
+    location = orchestrator.save_location(
+        generated, party_level=party_level, campaign=campaign
+    )
+    return render(request, "populator/_location_card.html", {"location": location})
+
+
+@login_required
+@require_POST
+def generate_faction_slots(request, pk):
+    """htmx endpoint: generate N factions (with hierarchies) for a
+    location and return their card fragments. Characters are then
+    generated slot-by-slot on each faction's own page."""
+    location = get_object_or_404(Location, pk=pk, campaign__owner=request.user)
+    try:
+        num_factions = max(1, min(int(request.POST.get("num_factions", 3)), 5))
+    except ValueError:
+        num_factions = 3
+    hints = request.POST.get("hints", "").strip()
+    existing = [
+        f"{f.name} ({f.faction_type}, {f.alignment})"
+        for f in location.factions.filter(is_catchall=False)
+    ]
+
+    gen_location = orchestrator.to_generated_location(location)
+    factions = [
+        orchestrator.save_faction(location, generated)
+        for generated in engine.generate_factions(
+            gen_location, num_factions, hints=hints, existing=existing
+        )
+    ]
+    return render(request, "populator/_faction_cards.html", {"factions": factions})
 
 
 @login_required
@@ -85,6 +245,12 @@ def generate_character_slot(request, pk):
     gen_location = orchestrator.to_generated_location(faction.location)
     gen_faction = orchestrator.to_generated_faction(faction)
     slot = engine.slot_for_title(gen_faction, rank_title)
+    # The mob (+) form lets the DM invent a new archetype type; honor
+    # the requested tier when the title isn't in the hierarchy.
+    if request.POST.get("tier") == "mob" and slot.tier is not RankTier.MOB:
+        slot = engine.RankDefinition(
+            level=slot.level, tier=RankTier.MOB, title=slot.title, positions=3
+        )
     party_level = faction.location.party_level
 
     if slot.tier is RankTier.MOB:
@@ -98,6 +264,7 @@ def generate_character_slot(request, pk):
             slot,
             existing=orchestrator.to_generated_characters(faction),
             user_hints=hints,
+            other_factions=orchestrator.other_faction_dossier(faction),
         )
         character = orchestrator.save_character(faction, generated)
         sheet_subject = generated
@@ -105,4 +272,24 @@ def generate_character_slot(request, pk):
     sheet = engine.generate_combat_sheet(sheet_subject, gen_faction, party_level, slot)
     orchestrator.save_combat_sheet(character, sheet)
 
-    return render(request, "populator/_character_card.html", {"character": character})
+    # Return the new card — plus a fresh slot form if this rank still
+    # has unfilled positions, so filling flows without page reloads.
+    html = render_to_string(
+        "populator/_character_card.html", {"character": character}, request
+    )
+    try:
+        remaining = int(request.POST.get("remaining", 1)) - 1
+    except ValueError:
+        remaining = 0
+    if remaining > 0:
+        html += render_to_string(
+            "populator/_slot_form.html",
+            {
+                "faction": faction,
+                "rank_title": rank_title,
+                "remaining": remaining,
+                "tier": request.POST.get("tier", ""),
+            },
+            request,
+        )
+    return HttpResponse(html)


### PR DESCRIPTION
## What
The second half of the generative UI work — ten modified files and three
template partials (`_slot_form`, `_location_card`, `_faction_cards`)
that were accidentally left uncommitted when the previous PR was pushed.

## Why
The previous PR merged incomplete; main currently references partials
this commit provides. Merging this makes main whole.